### PR TITLE
Don't look up a nil last_result_key

### DIFF
--- a/spec/sidekiq/clutch_spec.rb
+++ b/spec/sidekiq/clutch_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe Sidekiq::Clutch do
     )
   end
 
+  it 'does not attempt to look up results in Redis for jobs without a previous sibling' do
+    expect_any_instance_of(Sidekiq::Clutch::JobWrapper).not_to receive(:lookup_last_result)
+    subject.parallel do
+      subject.jobs << [Job2, 2, 'two']
+      subject.jobs << [Job2, 22, 222]
+    end
+    subject.engage
+    Sidekiq::Batch.drain_all_and_run_callbacks
+  end
+
   it 'can nest itself' do
     subject.jobs << [Job1, 1]
     subject.parallel do


### PR DESCRIPTION
Turns out Redis can store data with a nil key! This was blowing up in the case where there was already a value stored at the nil key.

Besides, we shouldn't be looking up data in Redis by nil.