### PR TITLE
Use Sidekiq wrapped option for better logging

### DIFF
--- a/lib/sidekiq/clutch.rb
+++ b/lib/sidekiq/clutch.rb
@@ -102,6 +102,7 @@ module Sidekiq
       options = {
         'class'     => JobWrapper,
         'queue'     => queue || job_options['queue'],
+        'wrapped'   => klass,
         'args'      => [batch.bid, klass, params, current_result_key, result_key],
         'retry'     => job_options['retry'],
         'backtrace' => job_options['backtrace']

--- a/spec/sidekiq/clutch_spec.rb
+++ b/spec/sidekiq/clutch_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe Sidekiq::Clutch do
     Sidekiq::Batch.drain_all_and_run_callbacks
   end
 
+  it 'supplies a wrapped class name to Sidekiq' do
+    subject.jobs << [Job2, 1, 2]
+    subject.engage
+    expect(Sidekiq::Worker.jobs.first).to include(
+      'class' => 'Sidekiq::Clutch::JobWrapper',
+      'queue' => 'low',
+      'wrapped' => 'Job2'
+    )
+    Sidekiq::Batch.drain_all_and_run_callbacks
+  end
+
   it 'does not execute the next step in series if a job failed' do
     expect(Job1).not_to receive(:new)
     subject.jobs << FailingJob


### PR DESCRIPTION
Hey @seven1m! 👋 

I've been using sidekiq-clutch lately, and it's been awesome! 🙇 

This is a just a small quality of life improvement that I thought was worthwhile. 

When using a wrapper class, Sidekiq's logging will show that class name for each job that's performed. So, using sidekiq-clutch logs a lot of `Sidekiq::Clutch::JobWrapper` jobs. To make the logs a bit more useful, we can pass the underlying job class name as the `wrapped` option, and Sidekiq will use that for the logs instead.

