### PR TITLE
Treat each parallel block as a distinct step

### DIFF
--- a/lib/sidekiq/clutch.rb
+++ b/lib/sidekiq/clutch.rb
@@ -10,18 +10,18 @@ module Sidekiq
       @batch = batch || Sidekiq::Batch.new
     end
 
-    attr_reader :batch, :queue
+    attr_reader :batch, :queue, :parallel_key
 
     attr_accessor :current_result_key, :on_failure
 
     def parallel
-      @parallel = true
+      @parallel_key = SecureRandom.uuid
       yield
-      @parallel = false
+      @parallel_key = nil
     end
 
     def parallel?
-      @parallel == true
+      !!@parallel_key
     end
 
     def jobs


### PR DESCRIPTION
Before this change, consecutive parallel blocks would effectively be treated (and ultimately processed) as a single step of work to be done in parallel. For example:

```ruby
clutch = Sidekiq::Clutch.new
clutch.parallel do
  widgets.each do |w|
    clutch.jobs << [Step1, w.id]
  end
end
clutch.parallel do
  widgets.each do |w|
    clutch.jobs << [Step2, w.id]
  end
end
```

This code, which might aims to perform Step1 on each widget, then perform Step2 on each widget after Step1 has finished, would actually perform Step1 and Step2 at the same time because from the `JobCollection`'s perspective, it's interacting with a `Clutch` in parallel mode the whole time.

This change treats each parallel block as a distinct step.

I realize that this is technically a breaking change, and I'm making assumptions here about how I _think_ this should work. I'm more than happy to explore other ways of accomplishing this goal if necessary.