### PR TITLE
Performance Tweaks

### DIFF
--- a/lib/sidekiq/clutch.rb
+++ b/lib/sidekiq/clutch.rb
@@ -54,7 +54,8 @@ module Sidekiq
       return if step.nil?
       batch.callback_queue = queue if queue
       batch.on(:success, Sidekiq::Clutch, 'jobs' => jobs_queue.dup, 'result_key' => step['result_key'])
-      batch.on(:complete, Sidekiq::Clutch, 'on_failure' => on_failure&.name)
+      on_failure_name = on_failure&.name
+      batch.on(:complete, Sidekiq::Clutch, 'on_failure' => on_failure_name) if on_failure_name
       batch.jobs do
         if step['series']
           series_step(step)

--- a/lib/sidekiq/clutch.rb
+++ b/lib/sidekiq/clutch.rb
@@ -113,8 +113,11 @@ module Sidekiq
 
     def clean_up_result_keys(key_base)
       Sidekiq.redis do |redis|
-        redis.keys(key_base + '*').each do |key|
-          redis.del(key)
+        result_key_index = 1
+        loop do
+          result = redis.del("#{key_base}-#{result_key_index}")
+          result_key_index += 1
+          break if result == 0
         end
       end
     end


### PR DESCRIPTION
This has two changes in it with the goal of improving performance:

1) Don't enqueue a completion handler if we know it will be a no-op anyway.

2) Avoid `KEYS` (or, as I learned the hard way, `SCAN`). With large data sets they're either crippling to Redis, painfully slow, or both. Instead, delete keys based on the known values, incrementing until we hit the end of them. HT to @seven1m for this idea.

These are both covered by existing tests so I don't think there are any changes in specs needed.