### PR TITLE
fix(Redis): clean up orphaned redis data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     parallelism: 1
     docker:
-    - image: circleci/ruby:2.5
+    - image: cimg/ruby:3.3
     - image: redis:3.2
     steps:
     - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
     - image: redis:3.2
     steps:
     - checkout
+    - run: sed -i "s/spec.add_dependency 'sidekiq', '>= 5.0.0'/spec.add_dependency 'sidekiq', '>= 5.0.0', '< 7.0.0'/" sidekiq-clutch.gemspec
     - run: gem install bundler
     - run: bundle install
     - run: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.2 - Feb 18, 2025
+
+* FIX: Don't leave orphaned redis keys laying around
+* CHANGE: Prefix redis keys for easier identification
+
 # 2.1.1 - Sep 14, 2021
 
 * FIX: Call correct clean up method when legacy jobs are finished

--- a/lib/sidekiq/clutch.rb
+++ b/lib/sidekiq/clutch.rb
@@ -89,7 +89,7 @@ module Sidekiq
       service = self.class.new(parent_batch)
       service.key_base = @key_base
       service.jobs.raw = remaining_jobs
-      service.current_result_key = "#{key_base}-#{options['result_key_index']}"
+      service.current_result_key = "#{key_base}:result-#{options['result_key_index']}"
       service.engage
     end
 
@@ -116,11 +116,11 @@ module Sidekiq
     end
 
     def key_base
-      @key_base ||= SecureRandom.uuid
+      @key_base ||= "clutch:#{SecureRandom.uuid}"
     end
 
     def jobs_key
-      "#{key_base}-jobs"
+      "#{key_base}:jobs"
     end
 
     def set_jobs_data_in_redis(data)
@@ -155,7 +155,7 @@ module Sidekiq
 
     def enqueue_job(klass, params, result_key_index)
       job_options = Object.const_get(klass).sidekiq_options
-      result_key = "#{key_base}-#{result_key_index}"
+      result_key = "#{key_base}:result-#{result_key_index}"
       options = {
         'class'     => JobWrapper,
         'queue'     => queue || job_options['queue'],
@@ -172,7 +172,7 @@ module Sidekiq
         redis.del(jobs_key)
         result_key_index = 1
         loop do
-          result = redis.del("#{key_base}-#{result_key_index}")
+          result = redis.del("#{key_base}:result-#{result_key_index}")
           result_key_index += 1
           break if result == 0
         end

--- a/lib/sidekiq/clutch.rb
+++ b/lib/sidekiq/clutch.rb
@@ -14,8 +14,8 @@ module Sidekiq
     end
 
     attr_reader :batch, :queue, :parallel_key
-
     attr_accessor :current_result_key, :on_failure
+    attr_writer :key_base
 
     def parallel
       @parallel_key = SecureRandom.uuid
@@ -87,6 +87,7 @@ module Sidekiq
       end
       parent_batch = Sidekiq::Batch.new(status.parent_bid)
       service = self.class.new(parent_batch)
+      service.key_base = @key_base
       service.jobs.raw = remaining_jobs
       service.current_result_key = "#{key_base}-#{options['result_key_index']}"
       service.engage

--- a/lib/sidekiq/clutch/version.rb
+++ b/lib/sidekiq/clutch/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   class Clutch
-    VERSION = '2.1.1'.freeze
+    VERSION = '2.1.2'.freeze
   end
 end

--- a/sidekiq-clutch.gemspec
+++ b/sidekiq-clutch.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'sidekiq', '>= 5.0.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.2.4'
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rspec', '~> 3.9.0'
 end


### PR DESCRIPTION
We were accidentally setting a new `key_base` for each parallel batch, oops! That means we weren't cleaning up the redis keys after a successful run, which means redis memory usage would balloon.

I also took the opportunity here to prefix the Redis keys for easier identification, since debugging this problem took a good deal of looking at the sea of redis data. 😄 

Now the keys look like this:

- `clutch:db694a2e-64cf-40be-b2c8-ae94e8a77038:jobs`
- `clutch:db694a2e-64cf-40be-b2c8-ae94e8a77038:result-1`
- `clutch:db694a2e-64cf-40be-b2c8-ae94e8a77038:result-2`